### PR TITLE
No more FileNotFoundError

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,17 @@
 History
 =======
 
+Upcoming 0.9.6
+--------------
+
+* Py2/Py3 agnostic ``FileNotFoundError``
+
+* SSH Key generation
+
+* Installing with ``pip -v`` gives you a message about PATH and PYTHONPATH.
+  However, the ``-v`` is **required** for this to show up. See here:
+  https://github.com/pypa/pip/issues/2933
+
 0.9.5 (2019-09-16)
 ------------------
 Install seems to work for Chris. Dependencies still need to be more tightly controlled.

--- a/esm_viz/deployment/__init__.py
+++ b/esm_viz/deployment/__init__.py
@@ -50,6 +50,12 @@ import paramiko
 # wat?
 from esm_viz import esm_viz
 
+# Py2 Py3 Fix: this has implications for the actual type of IO error, but...OK
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 
 def rexists(sftp, path):
     """

--- a/esm_viz/deployment/__init__.py
+++ b/esm_viz/deployment/__init__.py
@@ -476,7 +476,7 @@ class Simulation_Monitor(object):
                 logging.info(tag)
                 for line in stream.readlines():
                     logging.info(line)
-            except OSError:
+            except (OSError, IOError):
                 logging.info("Couldn't open %s", tag)
         self.ssh.close()
 


### PR DESCRIPTION
This branch allows supports Python 2 and Python 3 agnostic versions of the `FileNotFoundError`.

# Testing it:

To check it out and see if it works, please use the following to get exactly this branch:

```
$ pip uninstall esm_viz
$ pip install --user git+https://github.com/pgierz/esm-viz.git@py2py3_fileerror
```

Note the `@<branchname>` syntax in the pip command above. Remember to change `<branchname>` above, in this case to `py2py3_fileerror`

Next, please post the results of the following:

```
$ esm_viz show-paths
$ esm_viz deploy --expid=example
```

Replace `<something>` above with something that makes sense. I guess you have a configured `yaml` file for your `hist` run.

As a hint:

```
$ ls ${HOME}/.config/monitoring
... something with example.yaml or hist.yaml ...
```

# Pre-reqs:

The following should be guarenteed for your account:

+ [ ] You can log in to whatever test account without needing a password on the shell (i.e. working `rsa` keys for SSH)

# Expected Results:

If I did my homework correctly (fingers crossed); I'd expect this branch to do the following:

+ Log on to the remote supercomputer (I guess mistral)  
+ Run some sort of analysis script (I guess you have `temp2` timeseries)
+ Copy back the results to your machine (your machine in this case means `paleosrv1` plus whatever path you gave in the config file)

# How to validate it:

Can you do `ncview` on the file that was copied to `paleosrv1`?


- - - - 

The whole `SSHKeyExecption` has a seperate branch and seperate pull request. I'm writing that one next to give you some testing instructions.

Thanks for testing! I think we are getting close!