### PR TITLE
SSH Exception Bypass

### DIFF
--- a/esm_viz/deployment/__init__.py
+++ b/esm_viz/deployment/__init__.py
@@ -289,7 +289,8 @@ class Simulation_Monitor(object):
             self.ssh.connect(self.host, username=self.user)
             self.ssh.close()
             return True
-        except paramiko.ssh_exception.AuthenticationException:
+        # PG: This next line probably has implications I am not considering...
+        except paramiko.ssh_exception.SSHException:
             return False
 
     def _connect(self):
@@ -399,12 +400,14 @@ class Simulation_Monitor(object):
             remote_analysis_script_directory = self._determine_remote_analysis_dir(
                 component
             )
+            # FIXME: Chris wants this to be a user defined option
             remote_script = (
                 remote_analysis_script_directory
                 + "/"
                 + os.path.basename(analysis_script)
             )
             logging.info("The analysis script will be copied to: %s", remote_script)
+            # FIXME: Chris wants confirmation for this
             if not rexists(sftp, remote_analysis_script_directory):
                 mkdir_p(sftp, remote_analysis_script_directory)
             if not rexists(sftp, remote_script):


### PR DESCRIPTION
Probably closes #21

This branch makes sure that the `paramiko SSHException` doesn't interfere with
`esm_viz`'s `SSH` keys.

# How to test it:

`pip install` this branch. See Merge Request #23 for more info on how that works.

# Pre-reqs:

Ensure that you **cannot** log into the remote server with ssh keys. These should be generated for you automagically (yes, magic)

# Expected Results:

`esm_viz` should ask you about generating keys and make them if needed. I can almost guarentee that I forgot a `mkdir` somewhere, so don't be surprised by "sloppy" errors.

# How to validate it:

Running `esm_viz deploy --expid=<something>" with a valid `<something>` and **without** ssh keys should prompt you to generate things.